### PR TITLE
Add default github issue templates under ros2 org.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,9 @@ body:
   - type: checkboxes
     attributes:
       label: Is there an existing issue for this?
-      description: Please search to see if an issue already exists for the bug you encountered.
+      description: |
+        Please search to see if an issue already exists for the bug you encountered.
+        Please be mindful that some bugs may be attributable to individual ROS packages.
       options:
       - label: I have searched the existing issues
         required: true
@@ -17,6 +19,8 @@ body:
     attributes:
       label: Regression
       description: Is the reported bug a regression? If so, what is the last version of ROS where it still worked fine?
+    validations:
+      required: false
   - type: input
     id: os
     attributes:
@@ -44,6 +48,13 @@ body:
         **Examples:** *rmw_fastrtps_cpp*, *rmw_connextdds*, *rmw_cyclonedds_cpp*, ...
         You can check the ROS Middleware (RMW) implementation with the command: `ros2 doctor --report`
         Find the line starting with `middleware name` in the report.
+    validations:
+      required: false
+  - type: textarea
+    id: rmw_configuration
+    attributes:
+      label: "RMW Configuration (if applicable):"
+      description: If you apply RMW specific configuration, post it here.
     validations:
       required: false
   - type: input

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,22 +5,6 @@ body:
   - type: markdown
     attributes:
       value: "**Required Info:**"
-  - type: checkboxes
-    attributes:
-      label: Is there an existing issue for this?
-      description: |
-        Please search to see if an issue already exists for the bug you encountered.
-        Please be mindful that some bugs may be attributable to individual ROS packages.
-      options:
-      - label: I have searched the existing issues
-        required: true
-  - type: textarea
-    id: regression
-    attributes:
-      label: Regression
-      description: Is the reported bug a regression? If so, what is the last version of ROS where it still worked fine?
-    validations:
-      required: false
   - type: input
     id: os
     attributes:
@@ -106,5 +90,8 @@ body:
     id: addinfo
     attributes:
       label: "Additional information"
+      description: |
+        Please note any additional information to share here.
+        e.g) Is the reported bug a regression? If so, what is the last version of ROS where it still worked fine?
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,99 @@
+name: Bug Report
+description: File a bug report.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: "**Required Info:**"
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
+  - type: textarea
+    id: regression
+    attributes:
+      label: Regression
+      description: Is the reported bug a regression? If so, what is the last version of ROS where it still worked fine?
+  - type: input
+    id: os
+    attributes:
+      label: "Operating System:"
+      description: |
+        Please try to be specific.
+        For Linux, please use the command `uname -a` from a terminal and copy paste its output here.
+        For Windows, open a terminal (Win key + R and type `cmd`), type the command `ver` and press enter.
+        Then copy paste the output here.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: "ROS version or commit hash:"
+      description: |
+        **Examples:**  *humble*, *jazzy*, ...
+    validations:
+      required: true
+  - type: input
+    id: rmw
+    attributes:
+      label: "RMW implementation (if applicable):"
+      description: |
+        **Examples:** *rmw_fastrtps_cpp*, *rmw_connextdds*, *rmw_cyclonedds_cpp*, ...
+        You can check the ROS Middleware (RMW) implementation with the command: `ros2 doctor --report`
+        Find the line starting with `middleware name` in the report.
+    validations:
+      required: false
+  - type: input
+    id: clientlib
+    attributes:
+      label: "Client library (if applicable):"
+      description: |
+        **Examples:** *rclcpp*, *rclpy*, ...
+        Client libraries are the APIs that allow users to implement their ROS 2 code.
+    validations:
+      required: false
+  - type: textarea
+    id: doctor
+    attributes:
+      label: "'ros2 doctor --report' output"
+      description: |
+        It can help us knowing the details of your ROS environment.
+        Please use the command `ros2 doctor --report` and copy paste its output here.
+      render: Formatted
+    validations:
+      required: false
+  - type: textarea
+    id: repro
+    attributes:
+      label: "Steps to reproduce issue"
+      description: |
+        How do you trigger this bug? Please walk us through it step by step.
+        Include all the commands you ran in the exact order you ran them so that anyone can reproduce the bug.
+      placeholder: |
+        1.
+        2.
+        3.
+        ...
+    validations:
+      required: true
+  - type: textarea
+    id:  expected
+    attributes:
+      label: "Expected behavior"
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: "Actual behavior"
+    validations:
+      required: true
+  - type: textarea
+    id: addinfo
+    attributes:
+      label: "Additional information"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -9,3 +9,9 @@ contact_links:
   - name: ROS Discourse
     url: https://discourse.ros.org/
     about: Discussion on ROS and ROS-related things.
+  - name: ROS Discord
+    url: https://discord.com/servers/open-robotics-1077825543698927656
+    about: ROS & Gazebo Discord Server.
+  - name: ROS Status Page
+    url: https://status.openrobotics.org/
+    about: Status page for ROS websites and resources.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Robotics Stack Exchange
+    url: https://robotics.stackexchange.com/
+    about: Please ask and answer questions here.
+  - name: Documentation for Active ROS Distributions
+    url: https://docs.ros.org/
+    about: Please check our documentation here.
+  - name: ROS Discourse
+    url: https://discourse.ros.org/
+    about: Discussion on ROS and ROS-related things.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: File a feature request.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: "Thanks for taking the time to fill out this feature request form!"
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Description in a few sentences what the feature consists of and what problem it will solve.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Description what you are trying to solve, what is the problem to address with this Feature Request.
+    validations:
+      required: true
+  - type: textarea
+    id: implementation
+    attributes:
+      label: Design / Implementation Considerations
+    validations:
+      required: false
+      description: |
+        Relevant information on how the feature could be implemented and pros and cons of the different solutions.
+  - type: textarea
+    id: information
+    attributes:
+      label: Additional Information
+    validations:
+      required: false
+      description: |
+        If you have more details information, please describe here.


### PR DESCRIPTION
closes https://github.com/ros2/ros2/issues/1572

if we take this default org scope github issue and feature templates and configuration, we can close the following PRs all together.

- https://github.com/ros2/rclcpp/pull/2667
- https://github.com/ros2/rclpy/pull/1379
- https://github.com/ros2/ros2/pull/1606
- https://github.com/ros2/launch/pull/782