### PR TITLE
user details and summary for ros2 doctor output.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -57,7 +57,13 @@ body:
       description: |
         It can help us knowing the details of your ROS environment.
         Please use the command `ros2 doctor --report` and copy paste its output here.
-      render: Formatted
+      value: |
+        <details><summary>ros2 doc --report</summary>
+
+        ```console
+        <COPY OUTPUT HERE>
+        ```
+        </details>
     validations:
       required: false
   - type: textarea


### PR DESCRIPTION
The problem was `ros2 doctor --report` with `render: Formatted` has really long and occupies issue description. instead, we can use collapsible sections with the `<details>` and `<summary>` HTML tags.

with this, you can see `ros2 doctor --report` section like below.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/87b67ad5-7f51-4d8f-a3dc-b5973d5fcac5" />

so that user can copy and paste the console output, and that is filled in collapsible section.