### PR TITLE
Put OS info (uname -a) in codeblock to avoid linking to random issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,6 +14,10 @@ body:
         For Linux, please use the command `uname -a` from a terminal and copy paste its output here.
         For Windows, open a terminal (Win key + R and type `cmd`), type the command `ver` and press enter.
         Then copy paste the output here.
+      value: |
+        ```
+        <PUT OS INFO HERE>
+        ```
     validations:
       required: true
   - type: input


### PR DESCRIPTION
A typical `uname -a` output (on Ubuntu at least) includes `#` + some numbers, which is parsed by GitHub as a reference to an (unrelated) issue.

Avoid this by getting users to paste the `uname -a` output into a code block.

----

For example, mine is `Linux ul-pa-1255-1 5.15.0-134-generic #145-Ubuntu SMP Wed Feb 12 20:08:39 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux`. The `#145` would be parsed as a reference to an issue.

Some issues that do this:

* https://github.com/ros2/ros2cli/issues/1002
* https://github.com/ros2/ros2cli/issues/1009

There's probably a ton more, though. Note that users don't always include the `uname -a` output; sometimes they just include the Ubuntu version (example: https://github.com/ros2/rclcpp/issues/2799). However, I think it's fine to just put that info in a code block.