### PR TITLE
Remove discord link from ROS2 github organization page

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,9 +9,8 @@ Looking to get started with ROS? Our [installation guide is here](https://www.ro
 ## Community Resources
 
 * [ROS Discussion Forum](https://discourse.ros.org/)
-* [ROS Zulip Chat](https://openrobotics.zulipchat.com/) -- best for developer conversations.
-* [ROS Discord Server](https://discord.com/servers/open-robotics-1077825543698927656) -- best for new users.
-* [Robotics Stack Exchange](https://robotics.stackexchange.com/) (preferred ROS support forum).
+* [ROS Zulip Chat](https://openrobotics.zulipchat.com/) -- best for developer conversations
+* [Robotics Stack Exchange](https://robotics.stackexchange.com/) -- best for getting ROS support
 * [Official ROS Videos](https://vimeo.com/osrfoundation)
 * [ROSCon](https://roscon.ros.org), our yearly developer conference. 
 * Cite ROS 2 in academic work using [DOI: 10.1126/scirobotics.abm6074](https://www.science.org/doi/10.1126/scirobotics.abm6074)


### PR DESCRIPTION
## Description

This PR removes the discord link from the ROS 2 github organization page
<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Yes, they no longer will find the discord link here.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No
<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

This is based on the discussion held in Zulip: [Zulip conversation](https://openrobotics.zulipchat.com/#narrow/channel/526027-ROS-General/topic/Discord.20to.20Zulip.20in.20docs.3F/with/566882341)[#ROS General > Discord to Zulip in docs?](https://openrobotics.zulipchat.com/#narrow/channel/526027-ROS-General/topic/Discord.20to.20Zulip.20in.20docs.3F/with/566882341), which in turn based on the ROS discourse post here: https://discourse.openrobotics.org/t/open-robotics-launches-zulip-chat-server/50673
<!--
If applicable, provide any additional context or details about the changes.
-->
