### PR TITLE
Change discord to zulip in issue_template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -10,8 +10,9 @@ contact_links:
     url: https://discourse.ros.org/
     about: ROS Discourse is our community discussion forum.
   - name: 🔗 Do you need real time support from other ROS users?
-    url: https://discord.com/servers/open-robotics-1077825543698927656
-    about: Visit our community Discord server. ROS questions belong in "#ros-help" channel.
+    url: https://openrobotics.zulipchat.com/
+    about: Visit our community Zulip server. ROS questions belong in "ROS General" channel.
   - name: 🔗 Want to check ROS infrastructure status?
     url: https://status.openrobotics.org/
     about: Status page for ROS websites and resources.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -15,4 +15,3 @@ contact_links:
   - name: 🔗 Want to check ROS infrastructure status?
     url: https://status.openrobotics.org/
     about: Status page for ROS websites and resources.
-


### PR DESCRIPTION
I missed this when I did  PR #10, but this PR also removes the discord link from the issue_template.